### PR TITLE
Oprava použití standardního history API s Nette

### DIFF
--- a/client-side/history.ajax.js
+++ b/client-side/history.ajax.js
@@ -101,19 +101,21 @@ $.nette.ext('history', {
 	},
 	updateSnippets: function (snippets) {
 		var updatedSnippets = {};
-		$.each(snippets, function () {
-			var html;
-			if (this.excludedIds) {
-				var $html = $('<div>').html(this.html);
-				this.excludedIds.forEach(function (id) {
-					$html.find('#' + id).html($('#' + id).html());
-				});
-				html = $html.html();
-			} else {
-				html = this.html;
-			}
-			updatedSnippets[this.id] = html;
-		});
+		if (typeof snippets != "undefined") {
+			$.each(snippets, function () {
+				var html;
+				if (this.excludedIds) {
+					var $html = $('<div>').html(this.html);
+					this.excludedIds.forEach(function (id) {
+						$html.find('#' + id).html($('#' + id).html());
+					});
+					html = $html.html();
+				} else {
+					html = this.html;
+				}
+				updatedSnippets[this.id] = html;
+			});
+		}
 		this.snippetsExt.updateSnippets(updatedSnippets, true);
 		$.nette.load();
 	},


### PR DESCRIPTION
- Pokud se použila standardní funkce window.history.pushState() tak si toto rozšíření neumělo poradit s eventem onpopstate. Celé to bylo způsobené tím, že se ke každému stavu ukládají snippety a já tento stav ukládám bez snipetů, jelikož mě nezajímají.
